### PR TITLE
Added support for glob patterns

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -51,6 +51,16 @@ module.exports = function(grunt) {
           urls: ['www.twitter.com'],
           failOnError: true
         }
+      },
+      no_glob_pattern: {
+        options: {
+          urls: ['test/pages/test1.html']
+        }
+      },
+      glob_pattern: {
+        options: {
+          urls: ['test/pages/**/*.html']
+        }
       }
     },
 

--- a/package.json
+++ b/package.json
@@ -28,10 +28,12 @@
     "test": "grunt test"
   },
   "devDependencies": {
+    "globby": "^3.0.1",
     "grunt": "^0.4.5",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-jshint": "^0.10.0",
-    "grunt-contrib-nodeunit": "^0.4.1"
+    "grunt-contrib-nodeunit": "^0.4.1",
+    "protocolify": "^1.0.2"
   },
   "peerDependencies": {
     "grunt": "~0.4.5"

--- a/tasks/a11y.js
+++ b/tasks/a11y.js
@@ -8,11 +8,13 @@
 
 'use strict';
 
-var a11y       = require('a11y');
-var chalk      = require('chalk');
-var indent     = require('indent-string');
-var logSymbols = require('log-symbols');
-var Q          = require('q');
+var a11y        = require('a11y');
+var chalk       = require('chalk');
+var indent      = require('indent-string');
+var logSymbols  = require('log-symbols');
+var Q           = require('q');
+var globby      = require('globby');
+var protocolify = require('protocolify');
 
 var fail  = chalk.bold.red;
 var log   = chalk.blue;
@@ -32,7 +34,10 @@ module.exports = function(grunt) {
       viewportSize: '1024x768'
     });
 
-    var a11yPromises = options.urls.map(function (url) {
+    var urls = globby.sync(options.urls, {
+      nonull: true
+    }).map(protocolify);
+    var a11yPromises = urls.map(function (url) {
       return a11yPromise(url, options.viewportSize);
     });
 

--- a/test/a11y_test.js
+++ b/test/a11y_test.js
@@ -1,6 +1,12 @@
 'use strict';
 
 var grunt = require('grunt');
+var path = require('path');
+var exec = require('child_process').exec;
+var execOptions = {
+    cwd: path.join(__dirname, '..')
+};
+
 
 /*
   ======== A Handy Little Nodeunit Reference ========
@@ -46,4 +52,31 @@ exports.a11y = {
     test.equal(1, 1, 'as');
     test.done();
   },
+  no_glob_pattern: function(test) {
+    test.expect(1);
+    exec('grunt a11y:no_glob_pattern', execOptions, function(error, stdout) {
+      test.equal(
+        stdout.indexOf('Done, without errors') > -1,
+        true,
+        'Should support ordinary urls'
+      );
+      test.done();
+    });
+  },
+  glob_pattern: function(test) {
+    test.expect(2);
+    exec('grunt a11y:glob_pattern', execOptions, function(error, stdout) {
+      test.equal(
+        stdout.indexOf('Done, without errors') > -1,
+        true,
+        'Should support glob patterns as urls'
+      );
+      test.equal(
+        stdout.split('Report for').length == 3,
+        true,
+        'Should discover two files'
+      );
+      test.done();
+    });
+  }
 };

--- a/test/pages/morepages/test2.html
+++ b/test/pages/morepages/test2.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>My other test page</title>
+	</head>
+	<body>
+	</body>
+</html>

--- a/test/pages/test1.html
+++ b/test/pages/test1.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>My test page</title>
+	</head>
+	<body>
+	</body>
+</html>


### PR DESCRIPTION
Running `a11y` from the command line has glob pattern support but
the grunt plugin was missing this. This is due to the fact that
glob pattern support exists in the cli.js file which is not
exposed as such by the `a11y` module.

So now it should be possible to configure the plugin like this

```js
grunt.initConfig({
  a11y: {
    dev: {
      options: {
        urls: ['**/*.html']
      }
    }
  }
});
```

Unit tests showing this was added too using a black-box (and
somewhat crude) approach. I couldn't find a better way of testing
this for now.