### PR TITLE
fix: Moving protocolify to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "globby": "^3.0.1",
     "grunt": "^0.4.5",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-jshint": "^0.10.0",
@@ -43,9 +42,10 @@
   "dependencies": {
     "a11y": "^0.3.0",
     "chalk": "^1.0.0",
+    "globby": "^3.0.1",
     "indent-string": "^1.2.0",
     "log-symbols": "^1.0.1",
-    "q": "^1.1.2",
-    "protocolify": "^1.0.2"
+    "protocolify": "^1.0.2",
+    "q": "^1.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "grunt": "^0.4.5",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-jshint": "^0.10.0",
-    "grunt-contrib-nodeunit": "^0.4.1",
-    "protocolify": "^1.0.2"
+    "grunt-contrib-nodeunit": "^0.4.1"
   },
   "peerDependencies": {
     "grunt": "~0.4.5"
@@ -46,6 +45,7 @@
     "chalk": "^1.0.0",
     "indent-string": "^1.2.0",
     "log-symbols": "^1.0.1",
-    "q": "^1.1.2"
+    "q": "^1.1.2",
+    "protocolify": "^1.0.2"
   }
 }


### PR DESCRIPTION
There was an error when trying to run the grunt task that claimed that it couldn't find the module protocolify. Since it is being used in the primary grunt task, I'm moving it to the list of main dependencies so the module loads in the primary node_modules folder.