### PR TITLE
Globby and protocolify need to be real dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,10 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "globby": "^3.0.1",
     "grunt": "^0.4.5",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-jshint": "^0.10.0",
-    "grunt-contrib-nodeunit": "^0.4.1",
-    "protocolify": "^1.0.2"
+    "grunt-contrib-nodeunit": "^0.4.1"
   },
   "peerDependencies": {
     "grunt": "~0.4.5"
@@ -44,8 +42,10 @@
   "dependencies": {
     "a11y": "^0.3.0",
     "chalk": "^1.0.0",
+    "globby": "^3.0.1",
     "indent-string": "^1.2.0",
     "log-symbols": "^1.0.1",
+    "protocolify": "^1.0.2",
     "q": "^1.1.2"
   }
 }


### PR DESCRIPTION
Running the plugin was not possible before I put the globby and
protocolify dependencies as real dependencies and not dev
dependencies.

@lucalanca It seems like my initial PR missed this as I can
not make it work currently in my project without this.