### PR TITLE
update package dependecies and add verbose flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-a11y",
   "description": "Grunt wrapper for a11y",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "homepage": "https://github.com/lucalanca/grunt-a11y",
   "author": {
     "name": "Joao Figueiredo",
@@ -15,12 +15,10 @@
   "bugs": {
     "url": "https://github.com/lucalanca/grunt-a11y/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/lucalanca/grunt-a11y/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": {
+    "type": "MIT",
+    "url": "https://github.com/lucalanca/grunt-a11y/blob/master/LICENSE-MIT"
+  },
   "engines": {
     "node": ">= 0.8.0"
   },
@@ -28,19 +26,19 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt": "^0.4.5",
+    "grunt": "^1.0.1",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-jshint": "^0.12.0",
-    "grunt-contrib-nodeunit": "^0.4.1"
+    "grunt-contrib-nodeunit": "^1.0.0"
   },
   "peerDependencies": {
-    "grunt": "~0.4.5"
+    "grunt": "^1.0.1"
   },
   "keywords": [
-    "gruntplugin"
+    "gruntplugin", "accessibility", "a11y"
   ],
   "dependencies": {
-    "a11y": "^0.4.0",
+    "a11y": "^0.5.0",
     "chalk": "^1.0.0",
     "globby": "^4.0.0",
     "indent-string": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,7 @@
   "bugs": {
     "url": "https://github.com/lucalanca/grunt-a11y/issues"
   },
-  "license": {
-    "type": "MIT",
-    "url": "https://github.com/lucalanca/grunt-a11y/blob/master/LICENSE-MIT"
-  },
+  "license": "MIT",
   "engines": {
     "node": ">= 0.8.0"
   },


### PR DESCRIPTION
latest MacOS version no longer support running PhantomJS v1.9.x which fails with a segmentation fault error, while newer version v2.x is not affected

since a11y dependency requires the broken version it's not possible to execute it on latest mac, by updating a11y to 0.5 which relies on a newer version the issue is solved,

added also verbose flag to see the full output (default is false)

@lucalanca 